### PR TITLE
Add the read-only newscap dircap to the production grid config

### DIFF
--- a/credentials/production-grid.json
+++ b/credentials/production-grid.json
@@ -1,6 +1,7 @@
 {
   "version": "2",
   "nickname": "PrivateStorage",
+  "newscap": "URI:DIR2-RO:4nbaibh3k5fzm56u5dvtttrurq:j2mbmh7p6ax7mgvvah4ugsszqczmphgyfqptiz5ifoxh22i6fhyq",
   "zkap_unit_name": "GB-month",
   "zkap_unit_multiplier": 0.0006,
   "zkap_payment_url_root": "https://privatestorage.io/payment/",


### PR DESCRIPTION
Fixes PrivateStorageDesktop#376 (in the other tracker)