### PR TITLE
Add lease crawler configuration

### DIFF
--- a/credentials/production-grid.json
+++ b/credentials/production-grid.json
@@ -18,9 +18,9 @@
           "ristretto-issuer-root-url": "https://payments.privatestorage.io/",
           "pass-value": 1000000,
           "default-token-count": 50000,
-	  "lease.crawl-interval.mean": 864000,
-	  "lease.crawl-interval.range": 864000,
-	  "lease.min-time-remaining": 0,
+          "lease.crawl-interval.mean": 864000,
+          "lease.crawl-interval.range": 864000,
+          "lease.min-time-remaining": 0,
           "allowed-public-keys": "SoIGCPAsUq2S+LfkSqLtSyksqz6HyLSjqKuoBIkIEhU=,QF6UuJkml9EF9SVNK3LBIfsuYgIIibqmf8eS4GXYNAY=,OO2bRw4IjlSTeIIVhawWiluczNALg8eE1IRNLk7bC1w=,mlpW2eIac4OxPPu5uu/rsYq8iOSGJc5DiAWM9W6yhww="
         }
       ],
@@ -35,9 +35,9 @@
           "ristretto-issuer-root-url": "https://payments.privatestorage.io/",
           "pass-value": 1000000,
           "default-token-count": 50000,
-	  "lease.crawl-interval.mean": 864000,
-	  "lease.crawl-interval.range": 864000,
-	  "lease.min-time-remaining": 0,
+          "lease.crawl-interval.mean": 864000,
+          "lease.crawl-interval.range": 864000,
+          "lease.min-time-remaining": 0,
           "allowed-public-keys": "SoIGCPAsUq2S+LfkSqLtSyksqz6HyLSjqKuoBIkIEhU=,QF6UuJkml9EF9SVNK3LBIfsuYgIIibqmf8eS4GXYNAY=,OO2bRw4IjlSTeIIVhawWiluczNALg8eE1IRNLk7bC1w=,mlpW2eIac4OxPPu5uu/rsYq8iOSGJc5DiAWM9W6yhww="
         }
       ],
@@ -52,9 +52,9 @@
           "ristretto-issuer-root-url": "https://payments.privatestorage.io/",
           "pass-value": 1000000,
           "default-token-count": 50000,
-	  "lease.crawl-interval.mean": 864000,
-	  "lease.crawl-interval.range": 864000,
-	  "lease.min-time-remaining": 0,
+          "lease.crawl-interval.mean": 864000,
+          "lease.crawl-interval.range": 864000,
+          "lease.min-time-remaining": 0,
           "allowed-public-keys": "SoIGCPAsUq2S+LfkSqLtSyksqz6HyLSjqKuoBIkIEhU=,QF6UuJkml9EF9SVNK3LBIfsuYgIIibqmf8eS4GXYNAY=,OO2bRw4IjlSTeIIVhawWiluczNALg8eE1IRNLk7bC1w=,mlpW2eIac4OxPPu5uu/rsYq8iOSGJc5DiAWM9W6yhww="
         }
       ],
@@ -69,9 +69,9 @@
           "ristretto-issuer-root-url": "https://payments.privatestorage.io/",
           "pass-value": 1000000,
           "default-token-count": 50000,
-	  "lease.crawl-interval.mean": 864000,
-	  "lease.crawl-interval.range": 864000,
-	  "lease.min-time-remaining": 0,
+          "lease.crawl-interval.mean": 864000,
+          "lease.crawl-interval.range": 864000,
+          "lease.min-time-remaining": 0,
           "allowed-public-keys": "SoIGCPAsUq2S+LfkSqLtSyksqz6HyLSjqKuoBIkIEhU=,QF6UuJkml9EF9SVNK3LBIfsuYgIIibqmf8eS4GXYNAY=,OO2bRw4IjlSTeIIVhawWiluczNALg8eE1IRNLk7bC1w=,mlpW2eIac4OxPPu5uu/rsYq8iOSGJc5DiAWM9W6yhww="
         }
       ],
@@ -86,9 +86,9 @@
           "ristretto-issuer-root-url": "https://payments.privatestorage.io/",
           "pass-value": 1000000,
           "default-token-count": 50000,
-	  "lease.crawl-interval.mean": 864000,
-	  "lease.crawl-interval.range": 864000,
-	  "lease.min-time-remaining": 0,
+          "lease.crawl-interval.mean": 864000,
+          "lease.crawl-interval.range": 864000,
+          "lease.min-time-remaining": 0,
           "allowed-public-keys": "SoIGCPAsUq2S+LfkSqLtSyksqz6HyLSjqKuoBIkIEhU=,QF6UuJkml9EF9SVNK3LBIfsuYgIIibqmf8eS4GXYNAY=,OO2bRw4IjlSTeIIVhawWiluczNALg8eE1IRNLk7bC1w=,mlpW2eIac4OxPPu5uu/rsYq8iOSGJc5DiAWM9W6yhww="
         }
       ],

--- a/credentials/production-grid.json
+++ b/credentials/production-grid.json
@@ -18,6 +18,9 @@
           "ristretto-issuer-root-url": "https://payments.privatestorage.io/",
           "pass-value": 1000000,
           "default-token-count": 50000,
+	  "lease.crawl-interval.mean": "P10D",
+	  "lease.crawl-interval.range": "P1D",
+	  "lease.min-time-remaining": "P0D",
           "allowed-public-keys": "SoIGCPAsUq2S+LfkSqLtSyksqz6HyLSjqKuoBIkIEhU=,QF6UuJkml9EF9SVNK3LBIfsuYgIIibqmf8eS4GXYNAY=,OO2bRw4IjlSTeIIVhawWiluczNALg8eE1IRNLk7bC1w=,mlpW2eIac4OxPPu5uu/rsYq8iOSGJc5DiAWM9W6yhww="
         }
       ],
@@ -32,6 +35,9 @@
           "ristretto-issuer-root-url": "https://payments.privatestorage.io/",
           "pass-value": 1000000,
           "default-token-count": 50000,
+	  "lease.crawl-interval.mean": "P10D",
+	  "lease.crawl-interval.range": "P1D",
+	  "lease.min-time-remaining": "P0D",
           "allowed-public-keys": "SoIGCPAsUq2S+LfkSqLtSyksqz6HyLSjqKuoBIkIEhU=,QF6UuJkml9EF9SVNK3LBIfsuYgIIibqmf8eS4GXYNAY=,OO2bRw4IjlSTeIIVhawWiluczNALg8eE1IRNLk7bC1w=,mlpW2eIac4OxPPu5uu/rsYq8iOSGJc5DiAWM9W6yhww="
         }
       ],
@@ -46,6 +52,9 @@
           "ristretto-issuer-root-url": "https://payments.privatestorage.io/",
           "pass-value": 1000000,
           "default-token-count": 50000,
+	  "lease.crawl-interval.mean": "P10D",
+	  "lease.crawl-interval.range": "P1D",
+	  "lease.min-time-remaining": "P0D",
           "allowed-public-keys": "SoIGCPAsUq2S+LfkSqLtSyksqz6HyLSjqKuoBIkIEhU=,QF6UuJkml9EF9SVNK3LBIfsuYgIIibqmf8eS4GXYNAY=,OO2bRw4IjlSTeIIVhawWiluczNALg8eE1IRNLk7bC1w=,mlpW2eIac4OxPPu5uu/rsYq8iOSGJc5DiAWM9W6yhww="
         }
       ],
@@ -60,6 +69,9 @@
           "ristretto-issuer-root-url": "https://payments.privatestorage.io/",
           "pass-value": 1000000,
           "default-token-count": 50000,
+	  "lease.crawl-interval.mean": "P10D",
+	  "lease.crawl-interval.range": "P1D",
+	  "lease.min-time-remaining": "P0D",
           "allowed-public-keys": "SoIGCPAsUq2S+LfkSqLtSyksqz6HyLSjqKuoBIkIEhU=,QF6UuJkml9EF9SVNK3LBIfsuYgIIibqmf8eS4GXYNAY=,OO2bRw4IjlSTeIIVhawWiluczNALg8eE1IRNLk7bC1w=,mlpW2eIac4OxPPu5uu/rsYq8iOSGJc5DiAWM9W6yhww="
         }
       ],
@@ -74,6 +86,9 @@
           "ristretto-issuer-root-url": "https://payments.privatestorage.io/",
           "pass-value": 1000000,
           "default-token-count": 50000,
+	  "lease.crawl-interval.mean": "P10D",
+	  "lease.crawl-interval.range": "P1D",
+	  "lease.min-time-remaining": "P0D",
           "allowed-public-keys": "SoIGCPAsUq2S+LfkSqLtSyksqz6HyLSjqKuoBIkIEhU=,QF6UuJkml9EF9SVNK3LBIfsuYgIIibqmf8eS4GXYNAY=,OO2bRw4IjlSTeIIVhawWiluczNALg8eE1IRNLk7bC1w=,mlpW2eIac4OxPPu5uu/rsYq8iOSGJc5DiAWM9W6yhww="
         }
       ],

--- a/credentials/production-grid.json
+++ b/credentials/production-grid.json
@@ -19,7 +19,7 @@
           "pass-value": 1000000,
           "default-token-count": 50000,
           "lease.crawl-interval.mean": 864000,
-          "lease.crawl-interval.range": 864000,
+          "lease.crawl-interval.range": 86400,
           "lease.min-time-remaining": 0,
           "allowed-public-keys": "SoIGCPAsUq2S+LfkSqLtSyksqz6HyLSjqKuoBIkIEhU=,QF6UuJkml9EF9SVNK3LBIfsuYgIIibqmf8eS4GXYNAY=,OO2bRw4IjlSTeIIVhawWiluczNALg8eE1IRNLk7bC1w=,mlpW2eIac4OxPPu5uu/rsYq8iOSGJc5DiAWM9W6yhww="
         }
@@ -36,7 +36,7 @@
           "pass-value": 1000000,
           "default-token-count": 50000,
           "lease.crawl-interval.mean": 864000,
-          "lease.crawl-interval.range": 864000,
+          "lease.crawl-interval.range": 86400,
           "lease.min-time-remaining": 0,
           "allowed-public-keys": "SoIGCPAsUq2S+LfkSqLtSyksqz6HyLSjqKuoBIkIEhU=,QF6UuJkml9EF9SVNK3LBIfsuYgIIibqmf8eS4GXYNAY=,OO2bRw4IjlSTeIIVhawWiluczNALg8eE1IRNLk7bC1w=,mlpW2eIac4OxPPu5uu/rsYq8iOSGJc5DiAWM9W6yhww="
         }
@@ -53,7 +53,7 @@
           "pass-value": 1000000,
           "default-token-count": 50000,
           "lease.crawl-interval.mean": 864000,
-          "lease.crawl-interval.range": 864000,
+          "lease.crawl-interval.range": 86400,
           "lease.min-time-remaining": 0,
           "allowed-public-keys": "SoIGCPAsUq2S+LfkSqLtSyksqz6HyLSjqKuoBIkIEhU=,QF6UuJkml9EF9SVNK3LBIfsuYgIIibqmf8eS4GXYNAY=,OO2bRw4IjlSTeIIVhawWiluczNALg8eE1IRNLk7bC1w=,mlpW2eIac4OxPPu5uu/rsYq8iOSGJc5DiAWM9W6yhww="
         }
@@ -70,7 +70,7 @@
           "pass-value": 1000000,
           "default-token-count": 50000,
           "lease.crawl-interval.mean": 864000,
-          "lease.crawl-interval.range": 864000,
+          "lease.crawl-interval.range": 86400,
           "lease.min-time-remaining": 0,
           "allowed-public-keys": "SoIGCPAsUq2S+LfkSqLtSyksqz6HyLSjqKuoBIkIEhU=,QF6UuJkml9EF9SVNK3LBIfsuYgIIibqmf8eS4GXYNAY=,OO2bRw4IjlSTeIIVhawWiluczNALg8eE1IRNLk7bC1w=,mlpW2eIac4OxPPu5uu/rsYq8iOSGJc5DiAWM9W6yhww="
         }
@@ -87,7 +87,7 @@
           "pass-value": 1000000,
           "default-token-count": 50000,
           "lease.crawl-interval.mean": 864000,
-          "lease.crawl-interval.range": 864000,
+          "lease.crawl-interval.range": 86400,
           "lease.min-time-remaining": 0,
           "allowed-public-keys": "SoIGCPAsUq2S+LfkSqLtSyksqz6HyLSjqKuoBIkIEhU=,QF6UuJkml9EF9SVNK3LBIfsuYgIIibqmf8eS4GXYNAY=,OO2bRw4IjlSTeIIVhawWiluczNALg8eE1IRNLk7bC1w=,mlpW2eIac4OxPPu5uu/rsYq8iOSGJc5DiAWM9W6yhww="
         }

--- a/credentials/production-grid.json
+++ b/credentials/production-grid.json
@@ -18,9 +18,9 @@
           "ristretto-issuer-root-url": "https://payments.privatestorage.io/",
           "pass-value": 1000000,
           "default-token-count": 50000,
-	  "lease.crawl-interval.mean": "P10D",
-	  "lease.crawl-interval.range": "P1D",
-	  "lease.min-time-remaining": "P0D",
+	  "lease.crawl-interval.mean": 864000,
+	  "lease.crawl-interval.range": 864000,
+	  "lease.min-time-remaining": 0,
           "allowed-public-keys": "SoIGCPAsUq2S+LfkSqLtSyksqz6HyLSjqKuoBIkIEhU=,QF6UuJkml9EF9SVNK3LBIfsuYgIIibqmf8eS4GXYNAY=,OO2bRw4IjlSTeIIVhawWiluczNALg8eE1IRNLk7bC1w=,mlpW2eIac4OxPPu5uu/rsYq8iOSGJc5DiAWM9W6yhww="
         }
       ],
@@ -35,9 +35,9 @@
           "ristretto-issuer-root-url": "https://payments.privatestorage.io/",
           "pass-value": 1000000,
           "default-token-count": 50000,
-	  "lease.crawl-interval.mean": "P10D",
-	  "lease.crawl-interval.range": "P1D",
-	  "lease.min-time-remaining": "P0D",
+	  "lease.crawl-interval.mean": 864000,
+	  "lease.crawl-interval.range": 864000,
+	  "lease.min-time-remaining": 0,
           "allowed-public-keys": "SoIGCPAsUq2S+LfkSqLtSyksqz6HyLSjqKuoBIkIEhU=,QF6UuJkml9EF9SVNK3LBIfsuYgIIibqmf8eS4GXYNAY=,OO2bRw4IjlSTeIIVhawWiluczNALg8eE1IRNLk7bC1w=,mlpW2eIac4OxPPu5uu/rsYq8iOSGJc5DiAWM9W6yhww="
         }
       ],
@@ -52,9 +52,9 @@
           "ristretto-issuer-root-url": "https://payments.privatestorage.io/",
           "pass-value": 1000000,
           "default-token-count": 50000,
-	  "lease.crawl-interval.mean": "P10D",
-	  "lease.crawl-interval.range": "P1D",
-	  "lease.min-time-remaining": "P0D",
+	  "lease.crawl-interval.mean": 864000,
+	  "lease.crawl-interval.range": 864000,
+	  "lease.min-time-remaining": 0,
           "allowed-public-keys": "SoIGCPAsUq2S+LfkSqLtSyksqz6HyLSjqKuoBIkIEhU=,QF6UuJkml9EF9SVNK3LBIfsuYgIIibqmf8eS4GXYNAY=,OO2bRw4IjlSTeIIVhawWiluczNALg8eE1IRNLk7bC1w=,mlpW2eIac4OxPPu5uu/rsYq8iOSGJc5DiAWM9W6yhww="
         }
       ],
@@ -69,9 +69,9 @@
           "ristretto-issuer-root-url": "https://payments.privatestorage.io/",
           "pass-value": 1000000,
           "default-token-count": 50000,
-	  "lease.crawl-interval.mean": "P10D",
-	  "lease.crawl-interval.range": "P1D",
-	  "lease.min-time-remaining": "P0D",
+	  "lease.crawl-interval.mean": 864000,
+	  "lease.crawl-interval.range": 864000,
+	  "lease.min-time-remaining": 0,
           "allowed-public-keys": "SoIGCPAsUq2S+LfkSqLtSyksqz6HyLSjqKuoBIkIEhU=,QF6UuJkml9EF9SVNK3LBIfsuYgIIibqmf8eS4GXYNAY=,OO2bRw4IjlSTeIIVhawWiluczNALg8eE1IRNLk7bC1w=,mlpW2eIac4OxPPu5uu/rsYq8iOSGJc5DiAWM9W6yhww="
         }
       ],
@@ -86,9 +86,9 @@
           "ristretto-issuer-root-url": "https://payments.privatestorage.io/",
           "pass-value": 1000000,
           "default-token-count": 50000,
-	  "lease.crawl-interval.mean": "P10D",
-	  "lease.crawl-interval.range": "P1D",
-	  "lease.min-time-remaining": "P0D",
+	  "lease.crawl-interval.mean": 864000,
+	  "lease.crawl-interval.range": 864000,
+	  "lease.min-time-remaining": 0,
           "allowed-public-keys": "SoIGCPAsUq2S+LfkSqLtSyksqz6HyLSjqKuoBIkIEhU=,QF6UuJkml9EF9SVNK3LBIfsuYgIIibqmf8eS4GXYNAY=,OO2bRw4IjlSTeIIVhawWiluczNALg8eE1IRNLk7bC1w=,mlpW2eIac4OxPPu5uu/rsYq8iOSGJc5DiAWM9W6yhww="
         }
       ],

--- a/credentials/staging-grid.json
+++ b/credentials/staging-grid.json
@@ -17,10 +17,10 @@
                 "storage-server-FURL": "pb://7hcqwt2zhwsvh4swln2frvf7gmihx6nm@tcp:storage001.privatestorage-staging.com:8898/3gmes3xxifyaeywiwymlpx62x24atray",
 		"pass-value": 1000000,
 		"default-token-count": 50000,
+		"lease.crawl-interval.mean": 3600,
+		"lease.crawl-interval.range": 60,
+		"lease.min-time-remaining": 2592000,
 		"allowed-public-keys": "FgPm3fJz1SfE2p4AVAIbrB1xEzAWOY7v4MoijhLAT3g=,BJJVMlWPVY2dUu/0ZL5laqr40ynXXrdKlV59l0vU8wY=,xHS9p7Op+l8ksoKZ+taYVKjDElRaed9q1YShsaH8WQg=,RuofMb8S+Fdq9oWeS0JN4oERqJkcZg26iZImDnuGGW8=",
-		"lease.crawl-interval.mean": "PT1H",
-		"lease.crawl-interval.range": "PT15M",
-		"lease.min-time-remaining": "P30D"
             }]
         }
     }

--- a/credentials/staging-grid.json
+++ b/credentials/staging-grid.json
@@ -17,7 +17,10 @@
                 "storage-server-FURL": "pb://7hcqwt2zhwsvh4swln2frvf7gmihx6nm@tcp:storage001.privatestorage-staging.com:8898/3gmes3xxifyaeywiwymlpx62x24atray",
 		"pass-value": 1000000,
 		"default-token-count": 50000,
-		"allowed-public-keys": "FgPm3fJz1SfE2p4AVAIbrB1xEzAWOY7v4MoijhLAT3g=,BJJVMlWPVY2dUu/0ZL5laqr40ynXXrdKlV59l0vU8wY=,xHS9p7Op+l8ksoKZ+taYVKjDElRaed9q1YShsaH8WQg=,RuofMb8S+Fdq9oWeS0JN4oERqJkcZg26iZImDnuGGW8="
+		"allowed-public-keys": "FgPm3fJz1SfE2p4AVAIbrB1xEzAWOY7v4MoijhLAT3g=,BJJVMlWPVY2dUu/0ZL5laqr40ynXXrdKlV59l0vU8wY=,xHS9p7Op+l8ksoKZ+taYVKjDElRaed9q1YShsaH8WQg=,RuofMb8S+Fdq9oWeS0JN4oERqJkcZg26iZImDnuGGW8=",
+		"lease.crawl-interval.mean": "PT1H",
+		"lease.crawl-interval.range": "PT15M",
+		"lease.min-time-remaining": "P30D"
             }]
         }
     }

--- a/credentials/staging-grid.json
+++ b/credentials/staging-grid.json
@@ -15,12 +15,12 @@
                 "name": "privatestorageio-zkapauthz-v1",
                 "ristretto-issuer-root-url": "https://payments.privatestorage-staging.com/",
                 "storage-server-FURL": "pb://7hcqwt2zhwsvh4swln2frvf7gmihx6nm@tcp:storage001.privatestorage-staging.com:8898/3gmes3xxifyaeywiwymlpx62x24atray",
-		"pass-value": 1000000,
-		"default-token-count": 50000,
-		"lease.crawl-interval.mean": 3600,
-		"lease.crawl-interval.range": 60,
-		"lease.min-time-remaining": 2592000,
-		"allowed-public-keys": "FgPm3fJz1SfE2p4AVAIbrB1xEzAWOY7v4MoijhLAT3g=,BJJVMlWPVY2dUu/0ZL5laqr40ynXXrdKlV59l0vU8wY=,xHS9p7Op+l8ksoKZ+taYVKjDElRaed9q1YShsaH8WQg=,RuofMb8S+Fdq9oWeS0JN4oERqJkcZg26iZImDnuGGW8=",
+                "pass-value": 1000000,
+                "default-token-count": 50000,
+                "lease.crawl-interval.mean": 3600,
+                "lease.crawl-interval.range": 60,
+                "lease.min-time-remaining": 2592000,
+                "allowed-public-keys": "FgPm3fJz1SfE2p4AVAIbrB1xEzAWOY7v4MoijhLAT3g=,BJJVMlWPVY2dUu/0ZL5laqr40ynXXrdKlV59l0vU8wY=,xHS9p7Op+l8ksoKZ+taYVKjDElRaed9q1YShsaH8WQg=,RuofMb8S+Fdq9oWeS0JN4oERqJkcZg26iZImDnuGGW8="
             }]
         }
     }


### PR DESCRIPTION
Fixes #8 

I successfully manually tested this against GridSync 9ea708351591aad74ecc705fc919d9a3e3cdea8d and ZKAPAuthorizer 41446070c99adf0092d619e6ba09ca76d0454ce1 (which is the first revision that cares to load any of this configuration).  I tested as far as being able to connect to the staging grid.  I could not upload any files because the ZKAPAuthorizer on the staging grid disagrees with 9ea708351591aad74ecc705fc919d9a3e3cdea8d about pricing of mutables in a way that prevents directories from being created.  However, I could verify that the new ZKAPAuthorizer configuration values were loaded by the plugin.

