### PR TITLE
add a newscap for the staging grid

### DIFF
--- a/build/config.txt
+++ b/build/config.txt
@@ -43,3 +43,6 @@ signtool_timestamp_server = http://timestamp.digicert.com
 [wormhole]
 appid = tahoe-lafs.org/invite
 relay = ws://wormhole.tahoe-lafs.org:4000/v1
+
+[news:PrivateStorage Staging]
+check_delay_max = 60

--- a/credentials/staging-grid.json
+++ b/credentials/staging-grid.json
@@ -1,6 +1,7 @@
 {
     "version": "2",
     "nickname": "PrivateStorage Staging",
+    "newscap": "URI:DIR2-RO:fwa2zhapu2n7i4hnwrlnjhpc7q:aidc2lfxchdmyjuv5pmgcrv7fhmxnfjpa4qperbzzs27fqe3azjq",
     "zkap_unit_name": "GB-month",
     "zkap_unit_multiplier": 0.001,
     "zkap_payment_url_root": "https://time-for:grosse-pause@privatestorage-staging.com/333-switch-matomo-domain/payment/",


### PR DESCRIPTION
Production config already has a newscap configured.  This adds similar config for the staging grid so we can exercise newscap functionality on staging.
