### PR TITLE
Update Windows Authenticode certificate hash

### DIFF
--- a/build/config.txt
+++ b/build/config.txt
@@ -40,7 +40,7 @@ text = PrivateStorage is currently in <i>beta</i> and should not be considered s
 mac_developer_id = PrivateStorage.io, LLC
 gpg_key = 0x3416B3191931EE2E
 signtool_name = Private Storage.io, LLC
-signtool_sha1 = 4acad27db70c2347b4d430c6ebc8e7faf125683b
+signtool_sha1 = 08b4c160a598e394321161223299341ce7ca0b34
 signtool_timestamp_server = http://timestamp.digicert.com
 
 [wormhole]


### PR DESCRIPTION
PrivateStorage's Windows/Authenticode code-signing certificate expires this week. This PR updates the PrivateStorageDesktop global configuration file to sign builds with our newly-issued certificate moving forward (effective until the next expiry date of July 6, 2023).