### PR TITLE
Remove HTTP auth user/pass from ZKAP payment URL root in staging configuration

### DIFF
--- a/credentials/staging-grid.json
+++ b/credentials/staging-grid.json
@@ -4,7 +4,7 @@
     "newscap": "URI:DIR2-RO:fwa2zhapu2n7i4hnwrlnjhpc7q:aidc2lfxchdmyjuv5pmgcrv7fhmxnfjpa4qperbzzs27fqe3azjq",
     "zkap_unit_name": "GB-month",
     "zkap_unit_multiplier": 0.001,
-    "zkap_payment_url_root": "https://time-for:grosse-pause@privatestorage-staging.com/333-switch-matomo-domain/payment/",
+    "zkap_payment_url_root": "https://privatestorage-staging.com/333-switch-matomo-domain/payment/",
     "shares-needed": "1",
     "shares-happy": "1",
     "shares-total": "1",


### PR DESCRIPTION
This is no longer required.