### PR TITLE
Switch configuration for private.storage URLs to permanent versions

### DIFF
--- a/build/config.txt
+++ b/build/config.txt
@@ -28,7 +28,7 @@ multiple_grids = false
 tor = false
 
 [help]
-docs_url = https://private.storage/support
+docs_url = https://permanent.private.storage/support
 issues_url = mailto:support@private.storage
 
 [message]

--- a/credentials/production-grid.json
+++ b/credentials/production-grid.json
@@ -4,7 +4,7 @@
   "newscap": "URI:DIR2-RO:4nbaibh3k5fzm56u5dvtttrurq:j2mbmh7p6ax7mgvvah4ugsszqczmphgyfqptiz5ifoxh22i6fhyq",
   "zkap_unit_name": "GB-month",
   "zkap_unit_multiplier": 0.0006,
-  "zkap_payment_url_root": "https://private.storage/payment/",
+  "zkap_payment_url_root": "https://permanent.private.storage/payment/",
   "shares-needed": "3",
   "shares-happy": "4",
   "shares-total": "5",

--- a/credentials/production-grid.json
+++ b/credentials/production-grid.json
@@ -4,7 +4,7 @@
   "newscap": "URI:DIR2-RO:4nbaibh3k5fzm56u5dvtttrurq:j2mbmh7p6ax7mgvvah4ugsszqczmphgyfqptiz5ifoxh22i6fhyq",
   "zkap_unit_name": "GB-month",
   "zkap_unit_multiplier": 0.0006,
-  "zkap_payment_url_root": "https://permanent.private.storage/payment/",
+  "zkap_payment_url_root": "https://permanent.private.storage/payment",
   "shares-needed": "3",
   "shares-happy": "4",
   "shares-total": "5",

--- a/credentials/staging-grid.json
+++ b/credentials/staging-grid.json
@@ -4,7 +4,7 @@
     "newscap": "URI:DIR2-RO:fwa2zhapu2n7i4hnwrlnjhpc7q:aidc2lfxchdmyjuv5pmgcrv7fhmxnfjpa4qperbzzs27fqe3azjq",
     "zkap_unit_name": "GB-month",
     "zkap_unit_multiplier": 0.001,
-    "zkap_payment_url_root": "https://permanent.privatestorage-staging.com/payment/",
+    "zkap_payment_url_root": "https://permanent.privatestorage-staging.com/payment",
     "shares-needed": "1",
     "shares-happy": "1",
     "shares-total": "1",

--- a/credentials/staging-grid.json
+++ b/credentials/staging-grid.json
@@ -4,7 +4,7 @@
     "newscap": "URI:DIR2-RO:fwa2zhapu2n7i4hnwrlnjhpc7q:aidc2lfxchdmyjuv5pmgcrv7fhmxnfjpa4qperbzzs27fqe3azjq",
     "zkap_unit_name": "GB-month",
     "zkap_unit_multiplier": 0.001,
-    "zkap_payment_url_root": "https://privatestorage-staging.com/333-switch-matomo-domain/payment/",
+    "zkap_payment_url_root": "https://permanent.privatestorage-staging.com/payment/",
     "shares-needed": "1",
     "shares-happy": "1",
     "shares-total": "1",


### PR DESCRIPTION
This changes the configured URLs so they point to "permanent" versions.  These will always be available and can be updated server-side if we ever need them to refer to a different resource.  The response for these URLs will be a redirect to whatever location is correct at the time of the request.
