### PR TITLE
Add logging parameters to `config.txt`

### DIFF
--- a/build/config.txt
+++ b/build/config.txt
@@ -31,6 +31,11 @@ tor = false
 docs_url = https://permanent.private.storage/support
 issues_url = mailto:support@private.storage
 
+[logging]
+enabled = true
+max_bytes = 10000000
+backup_count = 1
+
 [message]
 type = warning
 title = Warning: Possible Bugs Ahead!

--- a/build/config.txt
+++ b/build/config.txt
@@ -15,9 +15,6 @@ version = 22.8.0
 [connection]
 default = production-grid
 
-[debug]
-log_maxlen = 140000
-
 [defaults]
 autostart = true
 


### PR DESCRIPTION
This PR exposes the default logging configuration values to `config.txt`, allowing them to be more easily tuned (and removes the old configuration related to the in-memory/deque-based log-handler which, after https://github.com/gridsync/gridsync/pull/570 are ignored).