### PR TITLE
Update Windows signing certificate for "PrivateStorage.io Inc."

### DIFF
--- a/build/config.txt
+++ b/build/config.txt
@@ -43,8 +43,8 @@ text = PrivateStorage is currently in <i>beta</i> and should not be considered s
 [sign]
 mac_developer_id = PrivateStorage.io Inc (WK2W3JQC34)
 gpg_key = 0x3416B3191931EE2E
-signtool_name = Private Storage.io, LLC
-signtool_sha1 = 08b4c160a598e394321161223299341ce7ca0b34
+signtool_name = PrivateStorage.io Inc.
+signtool_sha1 = 2246a8e868bf93f29af484c98b79640c861cdb9f
 signtool_timestamp_server = http://timestamp.digicert.com
 
 [wormhole]


### PR DESCRIPTION
PrivateStorage.io LLC has recently changed its legal name to "PrivateStorage.io Inc.". This PR updates the appropriate PrivateStorageDesktop build/signing config to use this new identity -- and, specifically, the new authenticode certificate issued by DigiCert -- for all builds moving forward.