### PR TITLE
Update Windows signing certificate

### DIFF
--- a/build/config.txt
+++ b/build/config.txt
@@ -38,7 +38,7 @@ backup_count = 1
 mac_developer_id = PrivateStorage.io Inc (WK2W3JQC34)
 gpg_key = 0x3416B3191931EE2E
 signtool_name = PrivateStorage.io Inc.
-signtool_sha1 = 2246a8e868bf93f29af484c98b79640c861cdb9f
+signtool_sha1 = 941738e99c5cfff123094261cffa3627ba94e0ec
 signtool_timestamp_server = http://timestamp.digicert.com
 
 [wormhole]


### PR DESCRIPTION
Closes https://whetstone.private.storage/privatestorage/privatestoragedesktop/-/issues/779

Note that this should not be merged until after the next public release of PrivateStorage (i.e., when a release superseding PrivateStorage 22.11.0 is made available for download on the private.storage website), or on July 7 (when the current signing certificate expires) -- whichever comes first.