### PR TITLE
Update Windows signing certificate

### DIFF
--- a/build/config.txt
+++ b/build/config.txt
@@ -38,7 +38,7 @@ backup_count = 1
 mac_developer_id = PrivateStorage.io Inc (WK2W3JQC34)
 gpg_key = 0x3416B3191931EE2E
 signtool_name = PrivateStorage.io Inc.
-signtool_sha1 = 941738e99c5cfff123094261cffa3627ba94e0ec
+signtool_sha1 = 0106a907faedcc908a47aca9636faea9b0b161e9
 signtool_timestamp_server = http://timestamp.digicert.com
 
 [wormhole]


### PR DESCRIPTION
The current Windows signing certificate is on the verge of expiry. This PR updates the PrivateStorageDesktop build config to use the new cert (valid through July 22, 2025).