### PR TITLE
Set "zkapauthorizer" feature-flag to "true"

### DIFF
--- a/build/config.txt
+++ b/build/config.txt
@@ -22,6 +22,7 @@ autostart = true
 grid_invites = false
 multiple_grids = false
 tor = false
+zkapauthorizer = true
 
 [help]
 docs_url = https://permanent.private.storage/support


### PR DESCRIPTION
This PR switches on the newly-introduced "zkapauthorizer" Gridsync feature-flag, enabling integration testing against the ZKAPAuthorizer plugin (e.g., in CI/buildbot runs). Without this set to "true", ZKAPAuthorizer-related integration tests will skipped.

See https://github.com/gridsync/gridsync/issues/733 https://github.com/gridsync/gridsync/pull/736